### PR TITLE
Add SystemConfig hierarchy

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,14 +22,16 @@ pip install -e .
 ## Usage
 
 Place per-device variables under ``host_vars``. For example the file
-``host_vars/router1.json`` contains clock data, interface definitions and
-BGP neighbors:
+``host_vars/router1.json`` contains system clock data, interface definitions
+and BGP neighbors:
 
 ```json
 {
-  "clock": {
-    "timezone": "UTC",
-    "ntp_servers": ["192.0.2.10", "192.0.2.11"]
+  "system": {
+    "clock": {
+      "timezone": "UTC",
+      "ntp_servers": ["192.0.2.10", "192.0.2.11"]
+    }
   },
   "interfaces": [
     {
@@ -61,4 +63,15 @@ Run the CLI to generate configuration (it looks in ``host_vars`` by default):
 
 ```bash
 openconf-cli router1
+```
+
+Group variables can supply defaults for multiple hosts. A simple file
+``group_vars/all.yml`` might look like:
+
+```yaml
+system:
+  clock:
+    timezone: UTC
+    ntp_servers:
+      - 192.0.2.20
 ```

--- a/group_vars/all.yml
+++ b/group_vars/all.yml
@@ -1,0 +1,5 @@
+system:
+  clock:
+    timezone: UTC
+    ntp_servers:
+      - 192.0.2.20

--- a/host_vars/router1.json
+++ b/host_vars/router1.json
@@ -1,8 +1,10 @@
 {
   "hostname": "router1",
-  "clock": {
-    "timezone": "UTC",
-    "ntp_servers": ["192.0.2.10", "192.0.2.11"]
+  "system": {
+    "clock": {
+      "timezone": "UTC",
+      "ntp_servers": ["192.0.2.10", "192.0.2.11"]
+    }
   },
   "interfaces": [
     {

--- a/openconf_device/device.py
+++ b/openconf_device/device.py
@@ -8,6 +8,7 @@ from .models import (
     DeviceConfig,
     Interface,
     ClockConfig,
+    SystemConfig,
     BgpConfig,
     BgpNeighbor,
 )
@@ -37,7 +38,9 @@ class NetworkDevice:
     def set_clock(self, timezone: str, ntp_servers: Optional[List[str]] = None) -> None:
         """Configure system clock."""
         ntp = ntp_servers or []
-        self.config.clock = ClockConfig(timezone=timezone, ntp_servers=ntp)
+        if self.config.system is None:
+            self.config.system = SystemConfig()
+        self.config.system.clock = ClockConfig(timezone=timezone, ntp_servers=ntp)
 
     def set_bgp(self, asn: int, neighbors: Optional[List[BgpNeighbor]] = None) -> None:
         """Set BGP ASN and optional neighbors."""

--- a/openconf_device/main.py
+++ b/openconf_device/main.py
@@ -18,6 +18,7 @@ from .models import (
     DeviceConfig,
     Interface,
     ClockConfig,
+    SystemConfig,
     BgpConfig,
     BgpNeighbor,
 )
@@ -61,9 +62,11 @@ def load_host_config(hostname: str, vars_dir: str = "host_vars") -> DeviceConfig
     for iface_data in data.get("interfaces", []):
         iface = Interface(**iface_data)
         device.add_interface(iface)
-    clock_data = data.get("clock")
+
+    system_data = data.get("system", {})
+    clock_data = system_data.get("clock")
     if clock_data:
-        device.clock = ClockConfig(**clock_data)
+        device.system = SystemConfig(clock=ClockConfig(**clock_data))
     bgp_data = data.get("bgp")
     if bgp_data:
         bgp = BgpConfig(asn=bgp_data.get("asn", 0))

--- a/openconf_device/models.py
+++ b/openconf_device/models.py
@@ -16,6 +16,17 @@ class ClockConfig:
 
 
 @dataclass
+class SystemConfig:
+    """System-wide settings."""
+    clock: Optional[ClockConfig] = None
+
+    def to_dict(self) -> dict:
+        return {
+            "clock": self.clock.to_dict() if self.clock else None,
+        }
+
+
+@dataclass
 class BgpNeighbor:
     """BGP neighbor configuration."""
     peer_ip: str
@@ -68,7 +79,7 @@ class DeviceConfig:
     """A collection of interfaces forming device configuration."""
     hostname: str
     interfaces: List[Interface] = field(default_factory=list)
-    clock: Optional[ClockConfig] = None
+    system: Optional[SystemConfig] = None
     bgp: Optional[BgpConfig] = None
 
     def add_interface(self, interface: Interface) -> None:
@@ -78,6 +89,6 @@ class DeviceConfig:
         return {
             "hostname": self.hostname,
             "interfaces": [iface.to_dict() for iface in self.interfaces],
-            "clock": self.clock.to_dict() if self.clock else None,
+            "system": self.system.to_dict() if self.system else None,
             "bgp": self.bgp.to_dict() if self.bgp else None,
         }


### PR DESCRIPTION
## Summary
- nest clock configuration under a new `SystemConfig` dataclass
- update loader and device helper for the new hierarchy
- adjust sample host/group vars and README documentation

## Testing
- `python -m openconf_device.main router1`

------
https://chatgpt.com/codex/tasks/task_e_6848b58b168c832d9bbccd25db5fdfe6